### PR TITLE
Attempt to speed up transformProperMotions

### DIFF
--- a/pygaia/astrometry/coordinates.py
+++ b/pygaia/astrometry/coordinates.py
@@ -4,7 +4,7 @@ from pygaia.astrometry.vectorastrometry import sphericalToCartesian, cartesianTo
         elementaryRotationMatrix, normalTriad
 from pygaia.utils import enum, degreesToRadians, radiansToDegrees
 
-from numpy import ones_like, array, pi, cos, sin, zeros_like
+from numpy import ones_like, array, pi, cos, sin, zeros_like, ndarray, sqrt, sum
 from numpy import dot, transpose, cross, vstack, diag, sqrt, identity
 from numpy.linalg import norm
 from scipy import isscalar
@@ -290,17 +290,15 @@ class CoordinateTransformation:
     zRot = self.rotationMatrix[2,:]
     zRotAll = zRot
     if (p.ndim == 2):
-      for i in range(p.shape[1]-1):
-        zRotAll = vstack((zRotAll,zRot))
+      zRotAll = ndarray((p.shape[1], zRotAll.shape[0]), dtype=zRot.dtype)
+      zRotAll[...] = zRot[None,...]
     pRot = cross(zRotAll, transpose(r))
     if (p.ndim == 2):
-      normPRot = sqrt(diag(dot(pRot,transpose(pRot))))
-      for i in range(pRot.shape[0]):
-        pRot[i,:] = pRot[i,:]/normPRot[i]
+      pRot = pRot/norm(pRot, axis=1)[:,None]
     else:
       pRot = pRot/norm(pRot)
 
     if (p.ndim == 2):
-      return diag(dot(pRot,p)), diag(dot(pRot,q))
+      return sum(pRot*transpose(p),axis=1), sum(pRot*transpose(q),axis=1)
     else:
       return dot(pRot,p), dot(pRot,q)


### PR DESCRIPTION
I've been trying to use transformProperMotions from pygaia.astrometry.coordinates on large arrays of proper motions. It seems to spend a lot of time in _getJacobian() in coordinates.py and I get MemoryError exceptions sometimes. I think there are a couple of things that might be causing this:

  * vstack is called in a loop on line 294. I think vstack makes a new array and copies all the elements on each call, so the total run time of the loop is proportional to the square of the number of elements
  
  * On line 297 the sqrt(diag(dot(...))) call makes an n*n matrix, where I think n is the number of elements in the input arrays. The run time and memory use will be proportional to n**2 here.

Here's my attempt at a fix - the vstack is replaced by allocating the full array up front and then doing an assignment, and normPRot can be found by using numpy.norm with the axis keyword.