### PR TITLE
Fix proper motions not propagated correctly

### DIFF
--- a/src/pygaia/astrometry/coordinates.py
+++ b/src/pygaia/astrometry/coordinates.py
@@ -597,7 +597,7 @@ class EpochPropagation:
         _, phi1, theta1 = cartesian_to_spherical(u[0], u[1], u[2])
         parallax1 = parallax * f
         pmr1 = (pmr0 + (pmtot0sqr + pmr0**2) * t) * f**2
-        pmvec1 = (pmvec0 * (1 + pmr0 * t) - r0 * pmr0**2 * t) * f**3
+        pmvec1 = (pmvec0 * (1 + pmr0 * t) - r0 * pmtot0sqr * t) * f**3
         p1, q1, r1 = normal_triad(phi1, theta1)
         muphistar1 = np.sum(p1 * pmvec1 / self.mastorad, axis=0)
         mutheta1 = np.sum(q1 * pmvec1 / self.mastorad, axis=0)
@@ -716,7 +716,7 @@ class EpochPropagation:
         par = par0 * f
 
         # Proper motion vector and radial proper motion at t1
-        pmvec = (pmvec0 * (one + pmr0 * tau) - r0 * pmr0**2 * tau) * f3
+        pmvec = (pmvec0 * (one + pmr0 * tau) - r0 * pm02 * tau) * f3
         pmr = (pmr0 + (pm02 + pmr0**2) * tau) * f2
 
         # Normal triad at t1


### PR DESCRIPTION
Thanks for this amazing package to show how astrometric data are propagated.

But I've found that the speed of a stars is not conserved when propagating to a different epoch. For example Acturus went from ~121.7 km/s at J2000 to ~95.3 km/s at J100000. Since the propagation assumes straight-line motion at constant speed, something is wrong. I've found a typo in the code leading to speed not conserved.

Here is a code snippet that I've used to sanity check
```python
from pygaia.astrometry.coordinates import EpochPropagation
from astroquery.simbad import Simbad
import numpy as np

MAS2RAD = 4.84813681109536e-9
PC_TO_KM = 3.086e13  # parsec to km
AU = 149597870.691  # astronomical unit in km
JYEAR_SECONDS = 31557600.0

customSimbad = Simbad()
customSimbad.add_votable_fields(
    "ra(d2000)", "dec(d2000)", "pmra", "pmdec", "otype", "plx", "plx_error", "rv_value"
)
result = customSimbad.query_object("Arcturus")

ra = result["RA_d2000"][0]
dec = result["DEC_d2000"][0]
pmra = result["PMRA"][0]
pmdec = result["PMDEC"][0]
plx = result["PLX_VALUE"][0]
rv = result["RV_VALUE"][0]

totvel = (
    np.sqrt(
        (
            np.sqrt(pmra**2 + pmdec**2)
            * (MAS2RAD / JYEAR_SECONDS)
            * PC_TO_KM
            * (1000 / plx)
        )
        ** 2
        + rv**2
    ),
)

ra_new, dec_new, parallax_new, pmra_new, pmdec_new, pmr_new = (
    EpochPropagation().propagate_astrometry(ra, dec, plx, pmra, pmdec, rv, 2000, 100000)
)

totvel_new = (
    np.sqrt(
        (
            np.sqrt(pmra_new**2 + pmdec_new**2)
            * (MAS2RAD / JYEAR_SECONDS)
            * PC_TO_KM
            * (1000 / parallax_new)
        )
        ** 2
        + ((pmr_new / parallax_new) * (AU / JYEAR_SECONDS)) ** 2
    ),
)

# these two values should be similar
print(totvel, totvel_new)
``` 

which will print `(np.float64(121.7675972466994),) (np.float64(95.28250254167489),)` and with this PR will print `(np.float64(121.7675972466994),) (np.float64(121.7609982767927),)`